### PR TITLE
string.opCall

### DIFF
--- a/croc/stdlib_string.d
+++ b/croc/stdlib_string.d
@@ -108,6 +108,7 @@ const uword VSplitMax = 20;
 const RegisterFunc[] _methodFuncs =
 [
 	{"format",       &_format},
+	{"opCall",       &_format},
 	{"join",         &_join,         maxParams: 1},
 	{"vjoin",        &_vjoin},
 	{"toInt",        &_toInt,        maxParams: 1},


### PR DESCRIPTION
I added one line to make string.opCall an alias of string.format.
This comes with a new format "syntax" for free:

"test {}" $ "lalala"
